### PR TITLE
Adds variables for social icon colors

### DIFF
--- a/template/assets/scss/variables.scss
+++ b/template/assets/scss/variables.scss
@@ -58,6 +58,12 @@ $grey:         $grey-60;
 $grey-light:   $grey-20;
 $grey-lighter: $grey-10;
 
+// brands
+$facebook: #3e5c98;
+$twitter: #2fa4f0;
+$youtube: #FF0000;
+$instagram: #DF2E75;
+
 $border: $grey-20;
 
 // PROJECT-SPECIFIC COLORS


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/aclu-national/nuxt-starter-template/commit/1fc355aae1b8bb90627a698346043fe7f0896b2c that references variables for the colors of the social icons, though the variables are not defined.

Project cannot compile without this!