### PR TITLE
Multiple updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $ npm install -g @vue/cli-init
 
 ### Steps for creating a new project based on this `nuxt-starter-template`:
 
-1. Initiate the vue project using this template:
+1. Initiate the Nuxt project using this template:
 
 ``` bash
 $ vue init aclu-national/nuxt-starter-template my-project
@@ -41,13 +41,15 @@ $ cd my-project
 
 2. Update the personal access token for `aclu-vue-library` (see devDependencies in `package.json`)
 
-3. Install dependencies
+3. [Import font files](https://github.com/aclu-national/style/tree/master/_reference/fonts/download)
+
+4. Install dependencies
 
 ``` bash
 $ npm install # Or yarn install
 ```
 
-4. Spin up the development server
+5. Spin up the development server
 
 ``` bash
 $ npm run dev

--- a/meta.js
+++ b/meta.js
@@ -21,6 +21,6 @@ module.exports = {
       'message': 'Author'
     },
   },
-  completeMessage: '{{#inPlace}}To get started:\n\n  npm install # Or yarn\n  npm run dev{{else}}To get started:\n\n  cd {{destDirName}}\n  npm install # Or yarn\n  npm run dev{{/inPlace}}'
+  completeMessage: '{{#inPlace}}To get started:\n\n  # Update personal access token for aclu-vue-plugin library - see package.json\n  # Import font files from github.com/aclu-national/style\n  npm install # Or yarn\n  npm run dev{{else}}To get started:\n\n  cd {{destDirName}}\n  # Update personal access token for aclu-vue-plugin library - see package.json\n  # Import font files from github.com/aclu-national/style\n  npm install # Or yarn\n  npm run dev{{/inPlace}}'
 };
 

--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
   parserOptions: {
     parser: 'babel-eslint',
     ecmaVersion: 2017,
-    sourceType: "module"
+    sourceType: 'module'
   },
   extends: [
     // https://github.com/vuejs/eslint-plugin-vue#priority-a-essential-error-prevention
@@ -28,14 +28,14 @@ module.exports = {
     'vue/html-quotes': [ 'warn' ],
     'vue/require-prop-types': [ 'warn' ],
     'vue/no-v-html': [ 'off' ],
-    "vue/html-self-closing": ["warn", {
-      "html": {
-        "void": "any",
-        "normal": "always",
-        "component": "always"
+    'vue/html-self-closing': ['warn', {
+      'html': {
+        'void': 'any',
+        'normal': 'always',
+        'component': 'always'
       }
     }],
-    "vue/html-closing-bracket-newline": [ 'warn' ],
+    'vue/html-closing-bracket-newline': [ 'warn' ],
     'vue/multiline-html-element-content-newline': ['warn', {
       'ignores': ['pre', 'textarea', 'span', 'b', 'strong', 'a']
     }],

--- a/template/.eslintrc.js
+++ b/template/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
   rules: {
     semi: [ 2, 'never' ],
     'no-console': [ 'off' ],
+    'vue/v-bind-style': [ 'off' ],
     'vue/no-unused-vars': [ 'warn' ],
     'vue/no-unused-components': [ 'warn' ],
     'vue/max-attributes-per-line': [ 'off' ],
@@ -44,6 +45,7 @@ module.exports = {
         semi: false,
         singleQuote: true,
         printWidth: 120,
+        proseWrap: 'preserve',
         htmlWhitespaceSensitivity: 'ignore',
         jsxBracketSameLine: true,
         eslintIntegration: true

--- a/template/assets/icons/icon-caret-231F20.svg
+++ b/template/assets/icons/icon-caret-231F20.svg
@@ -1,0 +1,3 @@
+<svg width="11" height="16" viewBox="0 0 11 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 12L6 6L0 0" transform="translate(2 2)" stroke="#231F20" stroke-width="3"/>
+</svg>

--- a/template/assets/scss/main.scss
+++ b/template/assets/scss/main.scss
@@ -1,35 +1,6 @@
-@import 'assets/scss/variables.scss';
 @import 'assets/scss/aclu-fonts.scss';
-@import 'assets/scss/spacing.scss';
-
-// MIXINS
-@mixin font-family-compressed () {
-  font-family: $aclu-sans-compressed;
-  line-height: 1;
-  letter-spacing: 0.005rem;
-  word-spacing: 0.1rem;
-  font-weight: $bold;
-}
-@mixin font-family-standard () {
-  font-family: $aclu-sans-standard;
-  line-height: 1.4;
-  letter-spacing: -0.005rem;
-  word-spacing: 0.0625rem;
-  font-weight: $normal;
-}
-@mixin font-family-standard-bold () {
-  font-family: $aclu-sans-standard;
-  line-height: 1.4;
-  letter-spacing: 0rem;
-  word-spacing: 0.0625rem;
-  font-weight: $bold;
-}
-@mixin font-family-serif () {
-  font-family: $aclu-serif;
-  line-height: 1.4;
-  letter-spacing: 0.01rem;
-  word-spacing: -0.12rem;
-}
+@import 'assets/scss/mixins.scss';
+// Mixins also pulls in variables.scss
 
 
 // TYPOGRAPHY
@@ -92,10 +63,7 @@ h6 {
 
 // Section title
 .is-section-title {
-  @include font-family-compressed;
-  font-size: $size-2;
-  text-transform: uppercase;
-  color: $offblack;
+  @include section-title;
 }
 
 
@@ -176,7 +144,7 @@ a {
 
     &:hover,
     &:focus {
-      color: rgba( $text, 0.5 );
+      opacity: $hover-opacity;
     }
   }
 }
@@ -190,6 +158,19 @@ nav a,
 button,
 .button {
   @include font-family-standard-bold;
+}
+button,
+.button {
+  border: none;
+
+  &.is-outlined {
+    border: 2px solid $offblack;
+  }
+
+  &:hover {
+    opacity: $hover-opacity;
+    color: inherit;
+  }
 }
 
 // FORMS
@@ -208,7 +189,7 @@ legend {
 
 
 button,
-input,
+input:not[type="radio"],
 .button {
   -moz-appearance: none;
   -webkit-appearance: none;
@@ -225,8 +206,20 @@ input,
   position: relative;
   vertical-align: top;
   border: 2px solid $offblack;
+
+  &.is-light {
+    border: 2px solid $white;
+    background-color: transparent;
+  }
+
 }
+input.has-error {
+  border: 2px solid $red !important;
+}
+
 input[type="text"],
+input[type="tel"],
+input[type="email"],
 input[type="search"],
 input.is-tall,
 button.is-tall,
@@ -235,6 +228,8 @@ button.is-tall,
   min-width: $inputHeightLarge;
 }
 input[type="text"],
+input[type="tel"],
+input[type="email"],
 input[type="search"]{
   padding: 18px 9px 0;
 }
@@ -272,16 +267,18 @@ input[type="search"]{
     background-image: url('~/assets/icons/icon-caret-0055aa.svg');
     transform: rotate(0deg);
     vertical-align: text-bottom;
-    height: 1em;
+    margin-top: 2px;
   }
   &.left {
     transform: rotate(180deg);
   }
-}
-a:hover .icon {
-  &.right,
-  &.left {
-    opacity: 0.7;
+  &.caret.is-light,
+  &.caret.is-light:hover {
+    background-image: url('~/assets/icons/icon-caret-ffffff.svg');
+  }
+  &.caret.is-dark,
+  &.caret.is-dark:hover {
+    background-image: url('~/assets/icons/icon-caret-231F20.svg');
   }
 }
 .round-icon {
@@ -293,7 +290,7 @@ a:hover .icon {
   background-repeat: no-repeat;
   background-position: center;
   background-size: auto;
-  
+
   &.is-twitter {
     background-image: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAiIGhlaWdodD0iMjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwKSIgZmlsbD0ibm9uZSI+PHBhdGggZD0iTTYuMjkgMTguMjU0YzcuNTQ4IDAgMTEuNjc1LTYuMjUzIDExLjY3NS0xMS42NzUgMC0uMTc3LS4wMDQtLjM1NC0uMDEyLS41M0E4LjM0NCA4LjM0NCAwIDAgMCAyMCAzLjkyNGE4LjE4MiA4LjE4MiAwIDAgMS0yLjM1Ni42NDYgNC4xMTggNC4xMTggMCAwIDAgMS44MDQtMi4yN2MtLjc5My40Ny0xLjY3LjgxMi0yLjYwNi45OTZBNC4xMDQgNC4xMDQgMCAwIDAgOS44NSA3LjAzOGExMS42NSAxMS42NSAwIDAgMS04LjQ1Ny00LjI4NyA0LjA5MiA0LjA5MiAwIDAgMC0uNTU2IDIuMDYzIDQuMSA0LjEgMCAwIDAgMS44MjYgMy40MTUgNC4wNzMgNC4wNzMgMCAwIDEtMS44NTgtLjUxM3YuMDUyYTQuMTA1IDQuMTA1IDAgMCAwIDMuMjkxIDQuMDIzIDQuMTA4IDQuMTA4IDAgMCAxLTEuODUzLjA3IDQuMTA4IDQuMTA4IDAgMCAwIDMuODMzIDIuODVBOC4yMzIgOC4yMzIgMCAwIDEgLjk4IDE2LjQ2OGMtLjMzMSAwLS42NTgtLjAyLS45NzktLjA1N2ExMS42MTUgMTEuNjE1IDAgMCAwIDYuMjkgMS44NDMiIGZpbGw9IiNmZmYiLz48L2c+PGRlZnM+PGNsaXBQYXRoIGlkPSJjbGlwMCI+PHBhdGggZmlsbD0iI2ZmZiIgZD0iTTAgMGgyMHYyMEgweiIvPjwvY2xpcFBhdGg+PC9kZWZzPjwvc3ZnPg==');
     background-size: 22px;
@@ -319,6 +316,14 @@ a:hover .icon {
 // HELPERS
 .nowrap {
   white-space: nowrap;
+}
+.ellipsis {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.is-relative {
+  position: relative;
 }
 
 // Centering helpers
@@ -361,10 +366,30 @@ a:hover .icon {
   flex-basis: auto;
 }
 
-// Overwrite Bulma's max container width on desktop+
-@media screen and (min-width: $desktop) {
+.container {
+  padding: 0 $spacer;
+}
+
+// Overwrite Bulma's max container width on tablet
+@media screen and (min-width: $tablet) and (max-width: $desktop) {
   .container {
-      max-width: 1140px;
-      width: 1140px;
+    width: $tabletContainerWidth;
   }
 }
+
+// Overwrite Bulma's max container width on desktop
+@media screen and (min-width: $desktop) {
+  .container {
+    width: $desktopContainerWidth;
+  }
+}
+
+// Overwrite Bulma's max container width on widescreen+
+@media screen and (min-width: $widescreen) {
+  .container {
+    width: $widescreenContainerWidth;
+  }
+}
+
+// Add spacing to the end to allow for tweaking
+@import 'assets/scss/spacing.scss';

--- a/template/assets/scss/mixins.scss
+++ b/template/assets/scss/mixins.scss
@@ -1,0 +1,37 @@
+@import 'assets/scss/variables.scss';
+
+// MIXINS
+@mixin font-family-compressed () {
+  font-family: $aclu-sans-compressed;
+  line-height: 1;
+  letter-spacing: 0.005rem;
+  word-spacing: 0.1rem;
+  font-weight: $bold;
+}
+@mixin font-family-standard () {
+  font-family: $aclu-sans-standard;
+  line-height: 1.4;
+  letter-spacing: -0.005rem;
+  word-spacing: 0.0625rem;
+  font-weight: $normal;
+}
+@mixin font-family-standard-bold () {
+  font-family: $aclu-sans-standard;
+  line-height: 1.4;
+  letter-spacing: 0rem;
+  word-spacing: 0.0625rem;
+  font-weight: $bold;
+}
+@mixin font-family-serif () {
+  font-family: $aclu-serif;
+  line-height: 1.4;
+  letter-spacing: 0.01rem;
+  word-spacing: -0.12rem;
+}
+
+@mixin section-title () {
+  @include font-family-compressed;
+  font-size: $size-2;
+  text-transform: uppercase;
+  color: $offblack;
+}

--- a/template/assets/scss/variables.scss
+++ b/template/assets/scss/variables.scss
@@ -69,16 +69,26 @@ $border: $grey-20;
 // PROJECT-SPECIFIC COLORS
 // Add here
 
-// SPACING
-$spacer: 15px;
-
 // FORMS
 $inputHeight: 45px;
 $inputHeightLarge: 60px;
 
-// BREAKPOINTS -- see initial-variables.scss
-$gap: 64px;
-$tablet: 600px;
-$desktop: 1200px;
-$widescreen: 1152px + (2 * $gap);
-$fullhd: 1344px + (2 * $gap);
+// SPACING & BREAKPOINTS
+$spacer: 15px;
+$mobileSpacer: 7px;
+$columnPadding: 15px;
+
+$gap: 30px;
+$desktopGap: 20px;
+
+$tabletContainerWidth: 540px;
+$desktopContainerWidth: 960px;
+$widescreenContainerWidth: 1140px;
+
+$tablet: $tabletContainerWidth + (2 * $gap);           // S: 600 - 999
+$desktop: $desktopContainerWidth + (2 * $desktopGap);  // M: 1000 - 1199
+$widescreen: $widescreenContainerWidth + (2 * $gap);   // L: 1200+
+
+// Not using Bulma's built-in fullhd breakpoint (disabled in bulma-overrides.scss)
+// $fullhd: 1344px + (2 * $gap);
+

--- a/template/assets/scss/variables.scss
+++ b/template/assets/scss/variables.scss
@@ -49,7 +49,7 @@ $grey-40: #999999;
 $grey-60: #666666;
 $grey-80: #333333;
 
-$light: $grey-10;
+$light: $light-slate; // $grey-10;
 $dark: $offblack;
 
 $grey-darker:  $offblack;
@@ -66,8 +66,8 @@ $instagram: #DF2E75;
 
 $border: $grey-20;
 
-// PROJECT-SPECIFIC COLORS
-// Add here
+// MISC
+$hover-opacity: 0.65;
 
 // FORMS
 $inputHeight: 45px;
@@ -91,4 +91,3 @@ $widescreen: $widescreenContainerWidth + (2 * $gap);   // L: 1200+
 
 // Not using Bulma's built-in fullhd breakpoint (disabled in bulma-overrides.scss)
 // $fullhd: 1344px + (2 * $gap);
-

--- a/template/components/Header.vue
+++ b/template/components/Header.vue
@@ -10,19 +10,9 @@
 </template>
 
 <style lang="scss" scoped>
-@import '~assets/scss/variables.scss';
-
+// Preserve space for nav while it loads
 .header {
-  // Preserve space for nav while it loads
-  height: 106px;
-}
-
-@media screen and (max-width: $tablet) {
-  .header {
-    height: 60px;
-  }
-  .section {
-    padding: 0;
-  }
+  height: 76px;
 }
 </style>
+

--- a/template/components/Header.vue
+++ b/template/components/Header.vue
@@ -15,4 +15,3 @@
   height: 76px;
 }
 </style>
-

--- a/template/components/ResponsivePageWrapper.vue
+++ b/template/components/ResponsivePageWrapper.vue
@@ -33,6 +33,9 @@ export default {
     setDevice() {
       // Breakpoints need to match those in variables.scss
       if (window.matchMedia('(min-width: 1200px)').matches) {
+        this.deviceBySize = 'widescreen'
+        this.isTouch = false
+      } else if (window.matchMedia('(min-width: 1000px)').matches) {
         this.deviceBySize = 'desktop'
         this.isTouch = false
       } else if (window.matchMedia('(max-width: 599px)').matches) {

--- a/template/nuxt.config.js
+++ b/template/nuxt.config.js
@@ -52,7 +52,7 @@ module.exports = {
   /*
   ** Plugins
   */
-  plugins: [{ src: '~plugins/aclu-vue-library', ssr: false }],
+  plugins: [{ src: '~plugins/aclu-vue-library', ssr: true }],
   /*
   ** Modules
   */

--- a/template/package.json
+++ b/template/package.json
@@ -26,7 +26,7 @@
     "eslint-friendly-formatter": "^3.0.0",
     "eslint-loader": "^2.1.1",
     "eslint-plugin-prettier": "^3.0.0",
-    "eslint-plugin-vue": "^5.0.0-beta.4",
+    "eslint-plugin-vue": "5.0.0-beta.4",
     "node-sass": "^4.9.3",
     "prettier": "1.15.2",
     "sass-loader": "^7.1.0"

--- a/template/plugins/aclu-vue-library.js
+++ b/template/plugins/aclu-vue-library.js
@@ -1,7 +1,7 @@
 import Vue from 'vue'
-// import SearchBox from 'aclu-vue-library'
 import BrandedNav from 'aclu-vue-library'
+import BrandedFooter from 'aclu-vue-library'
 import 'aclu-vue-library/dist/aclu-vue-library.css'
 
-// Vue.use(SearchBox)
 Vue.use(BrandedNav)
+Vue.use(BrandedFooter)


### PR DESCRIPTION
This PR includes multiple updates to the nuxt-starter-template:
- Updated variables.scss (including breakpoints!)
- Moved mixins to their own file (mixins.scss) so they're easier to import when needed
- Updated the `ResponsivePageWrapper` with new breakpoints and a new `'mq-widescreen'` class, if you ever need that ([here is an example of how those classes are used](https://github.com/aclu-national/action-page-frontend/blob/master/components/ActionCarousel.vue#L202-L232) - it's just yet another way of tweaking elements at for different screen sizes)
- Added more complete install steps to the readme and meta.js (that's what you see in the terminal immediately after creating a new project based on this template)
- Locked down the `eslint-plugin-vue` package  -- there was at least one new rule recently added that fights with prettier so I'm locking this down until the `eslint-plugin-prettier` package (which manages these conflicts) catches up.  This is just to avoid lots of lint warnings upon first setting up the project.

I'll merge this tomorrow to avoid holding up any development, but wanted you both to be aware of the incoming changes.  cc/ @kateray @hanbyul-here 