### PR TITLE
expanded spacing util to cover different screen sizes

### DIFF
--- a/template/assets/scss/spacing.scss
+++ b/template/assets/scss/spacing.scss
@@ -51,6 +51,8 @@ $positions: (
         .#{$paddingKey}#{$posKey}#{$separator}#{$sizeKey} {
             padding-#{$posValue}: sizeValue($sizeKey, $sizeValue) !important;
         }
+
+        // these util classes for different screen sizes are dependent on bulma's mixin for screen sizes
         @include mobile {
             .#{$paddingKey}#{$posKey}#{$separator}#{$sizeKey}-is-mobile {
                 padding-#{$posValue}: sizeValue($sizeKey, $sizeValue) !important;

--- a/template/assets/scss/spacing.scss
+++ b/template/assets/scss/spacing.scss
@@ -52,36 +52,44 @@ $positions: (
             padding-#{$posValue}: sizeValue($sizeKey, $sizeValue) !important;
         }
 
-        // these util classes for different screen sizes are dependent on bulma's mixin for screen sizes
+        // these util classes for different screen sizes are dependent on bulma's mixins for screen sizes
         @include mobile {
-            .#{$paddingKey}#{$posKey}#{$separator}#{$sizeKey}-is-mobile {
+            .#{$paddingKey}#{$posKey}#{$separator}#{$sizeKey}-mobile {
                 padding-#{$posValue}: sizeValue($sizeKey, $sizeValue) !important;
             }
-            .#{$marginKey}#{$posKey}#{$separator}#{$sizeKey}-is-mobile {
+            .#{$marginKey}#{$posKey}#{$separator}#{$sizeKey}-mobile {
                 margin-#{$posValue}: sizeValue($sizeKey, $sizeValue) !important;
             }
         }
         @include tablet {
-            .#{$paddingKey}#{$posKey}#{$separator}#{$sizeKey}-is-tablet {
+            .#{$paddingKey}#{$posKey}#{$separator}#{$sizeKey}-tablet {
                 padding-#{$posValue}: sizeValue($sizeKey, $sizeValue) !important;
             }
-            .#{$marginKey}#{$posKey}#{$separator}#{$sizeKey}-is-tablet {
+            .#{$marginKey}#{$posKey}#{$separator}#{$sizeKey}-tablet {
                 margin-#{$posValue}: sizeValue($sizeKey, $sizeValue) !important;
             }
         }
         @include touch {
-            .#{$paddingKey}#{$posKey}#{$separator}#{$sizeKey}-is-touch {
+            .#{$paddingKey}#{$posKey}#{$separator}#{$sizeKey}-touch {
                 padding-#{$posValue}: sizeValue($sizeKey, $sizeValue) !important;
             }
-            .#{$marginKey}#{$posKey}#{$separator}#{$sizeKey}-is-touch {
+            .#{$marginKey}#{$posKey}#{$separator}#{$sizeKey}-touch {
                 margin-#{$posValue}: sizeValue($sizeKey, $sizeValue) !important;
             }
         }
         @include desktop {
-            .#{$paddingKey}#{$posKey}#{$separator}#{$sizeKey}-is-desktop {
+            .#{$paddingKey}#{$posKey}#{$separator}#{$sizeKey}-desktop {
                 padding-#{$posValue}: sizeValue($sizeKey, $sizeValue) !important;
             }
-            .#{$marginKey}#{$posKey}#{$separator}#{$sizeKey}-is-desktop {
+            .#{$marginKey}#{$posKey}#{$separator}#{$sizeKey}-desktop {
+                margin-#{$posValue}: sizeValue($sizeKey, $sizeValue) !important;
+            }
+        }
+        @include widescreen {
+            .#{$paddingKey}#{$posKey}#{$separator}#{$sizeKey}-widescreen {
+                padding-#{$posValue}: sizeValue($sizeKey, $sizeValue) !important;
+            }
+            .#{$marginKey}#{$posKey}#{$separator}#{$sizeKey}-widescreen {
                 margin-#{$posValue}: sizeValue($sizeKey, $sizeValue) !important;
             }
         }

--- a/template/assets/scss/spacing.scss
+++ b/template/assets/scss/spacing.scss
@@ -51,5 +51,37 @@ $positions: (
         .#{$paddingKey}#{$posKey}#{$separator}#{$sizeKey} {
             padding-#{$posValue}: sizeValue($sizeKey, $sizeValue) !important;
         }
+        @include mobile {
+            .#{$paddingKey}#{$posKey}#{$separator}#{$sizeKey}-is-mobile {
+                padding-#{$posValue}: sizeValue($sizeKey, $sizeValue) !important;
+            }
+            .#{$marginKey}#{$posKey}#{$separator}#{$sizeKey}-is-mobile {
+                margin-#{$posValue}: sizeValue($sizeKey, $sizeValue) !important;
+            }
+        }
+        @include tablet {
+            .#{$paddingKey}#{$posKey}#{$separator}#{$sizeKey}-is-tablet {
+                padding-#{$posValue}: sizeValue($sizeKey, $sizeValue) !important;
+            }
+            .#{$marginKey}#{$posKey}#{$separator}#{$sizeKey}-is-tablet {
+                margin-#{$posValue}: sizeValue($sizeKey, $sizeValue) !important;
+            }
+        }
+        @include touch {
+            .#{$paddingKey}#{$posKey}#{$separator}#{$sizeKey}-is-touch {
+                padding-#{$posValue}: sizeValue($sizeKey, $sizeValue) !important;
+            }
+            .#{$marginKey}#{$posKey}#{$separator}#{$sizeKey}-is-touch {
+                margin-#{$posValue}: sizeValue($sizeKey, $sizeValue) !important;
+            }
+        }
+        @include desktop {
+            .#{$paddingKey}#{$posKey}#{$separator}#{$sizeKey}-is-desktop {
+                padding-#{$posValue}: sizeValue($sizeKey, $sizeValue) !important;
+            }
+            .#{$marginKey}#{$posKey}#{$separator}#{$sizeKey}-is-desktop {
+                margin-#{$posValue}: sizeValue($sizeKey, $sizeValue) !important;
+            }
+        }
     }
 }


### PR DESCRIPTION
- created spacing util classes for different screens

- I wish the change is a bit more dry.. but can't figure out how to loop through different mixin 🤔 

- This change is dependent on Bulma's mixin. I tested with local env (specifically with Scorecard), and these work. However, I am actually not sure Bulma's util is guaranteed when `spacing.scss` is compiled.   Is this syntax safe enough? @rfriberg 